### PR TITLE
Ndx2resttop fix

### DIFF
--- a/biobb_gromacs/gromacs/common.py
+++ b/biobb_gromacs/gromacs/common.py
@@ -263,13 +263,19 @@ def create_mdp(output_mdp_path: str, input_mdp_path: Optional[str] = None,
 
     if preset_dict:
         for k, v in preset_dict.items():
-            mdp_dict[k] = v
+            mdp_dict[clean_key(k)] = v
     if input_mdp_path:
         input_mdp_dict = read_mdp(input_mdp_path)
         for k, v in input_mdp_dict.items():
-            mdp_dict[k] = v
+            mdp_dict[clean_key(k)] = v
     if mdp_properties_dict:
         for k, v in mdp_properties_dict.items():
-            mdp_dict[k] = v
+            mdp_dict[clean_key(k)] = v
 
     return write_mdp(output_mdp_path, mdp_dict)
+
+def clean_key(key: str) -> str:
+    """ Cleans a keyword by converting it to lower case and replacing '_' by '-' as gromacs will not be sensitive to these differences and every keyword
+    can only be defined once in the MDP file. """
+    
+    return key.lower().replace('_', '-')

--- a/biobb_gromacs/gromacs/common.py
+++ b/biobb_gromacs/gromacs/common.py
@@ -138,7 +138,7 @@ def mdp_preset(sim_type: str) -> dict[str, str]:
 
     # Position restrain
     if not free:
-        mdp_dict['Define'] = '-DPOSRES'
+        mdp_dict['define'] = '-DPOSRES'
 
     # Run parameters
     mdp_dict['nsteps'] = '5000'

--- a/biobb_gromacs/gromacs_extra/ndx2resttop.py
+++ b/biobb_gromacs/gromacs_extra/ndx2resttop.py
@@ -126,15 +126,15 @@ class Ndx2resttop(BiobbObject):
             fu.log('Reference group: '+reference_group, self.out_log, self.global_log)
             fu.log('Restrain group: '+restrain_group, self.out_log, self.global_log)
             fu.log('Chain: '+chain, self.out_log, self.global_log)
-            self.io_dict['out']["output_itp_path"] = fu.create_name(path=str(Path(top_file).parent), prefix=self.prefix, step=self.step, name=restrain_group+'.itp')
-
+            self.io_dict['out']["output_itp_path"] = fu.create_name(path=str(Path(top_file).parent), prefix=self.prefix, step=self.step, name=restrain_group+'_posre.itp')
+            
             # Mapping atoms from absolute enumeration to Chain relative enumeration
             fu.log('reference_group_index: start_closed:'+str(index_dic['[ '+reference_group+' ]'][0]+1)+' stop_open: '+str(index_dic['[ '+reference_group+' ]'][1]), self.out_log, self.global_log)
             reference_group_list = [int(elem) for line in lines[index_dic['[ '+reference_group+' ]'][0]+1: index_dic['[ '+reference_group+' ]'][1]] for elem in line.split()]
             fu.log('restrain_group_index: start_closed:'+str(index_dic['[ '+restrain_group+' ]'][0]+1)+' stop_open: '+str(index_dic['[ '+restrain_group+' ]'][1]), self.out_log, self.global_log)
             restrain_group_list = [int(elem) for line in lines[index_dic['[ '+restrain_group+' ]'][0]+1: index_dic['[ '+restrain_group+' ]'][1]] for elem in line.split()]
             selected_list = [reference_group_list.index(atom)+1 for atom in restrain_group_list]
-            # Creating new ITP with restrictions
+            # Creating new ITP with restrains
             with open(self.io_dict['out'].get("output_itp_path", ''), 'w') as f:
                 fu.log('Creating: '+str(f)+' and adding the selected atoms force constants', self.out_log, self.global_log)
                 f.write('[ position_restraints ]\n')

--- a/biobb_gromacs/gromacs_extra/ndx2resttop.py
+++ b/biobb_gromacs/gromacs_extra/ndx2resttop.py
@@ -76,16 +76,31 @@ class Ndx2resttop(BiobbObject):
 
         top_file = fu.unzip_top(zip_file=self.io_dict['in'].get("input_top_zip_path", ""), out_log=self.out_log)
 
-        # Create index list of index file :)
+        # Create index list of index file (dictionary with the index of the start and stop lines of each group) :)
         index_dic: dict[str, Any] = {}
         lines = open(self.io_dict['in'].get("input_ndx_path", "")).read().splitlines()
         for index, line in enumerate(lines):
+            
+            # New group
             if line.startswith('['):
-                index_dic[line] = index,
-                label = line
+                index_dic[line] = [index, 0]
+                
+                # Close previous group
                 if index > 0:
-                    index_dic[label] = index_dic[label][0], index
-        index_dic[label] = index_dic[label][0], index
+                    index_dic[label] = [index_dic[label][0], index]
+                    
+                # Update current group
+                label = line
+            
+            # Last group of the file
+            if index == len(lines)-1:
+                index_dic[label] = [index_dic[label][0], index]
+        
+        # Catch groups with just one line
+        for label in index_dic.keys():
+            if (index_dic[label][0]+1) == index_dic[label][1]:
+                index_dic[label][1] += 1
+    
         fu.log('Index_dic: '+str(index_dic), self.out_log, self.global_log)
 
         self.ref_rest_chain_triplet_list = [tuple(elem.strip(' ()').replace(' ', '').split(',')) for elem in str(self.ref_rest_chain_triplet_list).split('),')]


### PR DESCRIPTION
Hi!

I leave here some changes that I have found necessary. Let me know what you think.

The modifications in common.py are due to the fact that the user can provide mdp keywords in a different format as the preset dictionary (e.g. using upper instead of lower case or using '_' instead of '-'). The mdp dictionary will have a keyword defined twice in those cases. And gromp will complain as it is not sensitive to those changes - not sure if there are more changes that should be taken into account. Cleaning the keywords before building the mdp dict solves the issue.

Changes in ndx2resttop are done to extend its use to topologies of a single chain. With a single chain pdb2gmx just writes the .top file instead of a .itp for each chain. I have also noticed different issues with how the index_dict was built that now should be corrected. Finally I added a custom posres keyword, so the user has more control over which position restraints are being activated. 

I'm available to discuss these changes in detail if needed, hope this helps :)

