### PR TITLE
feat: made trr optional

### DIFF
--- a/biobb_gromacs/gromacs/mdrun.py
+++ b/biobb_gromacs/gromacs/mdrun.py
@@ -137,12 +137,6 @@ class Mdrun(BiobbObject):
         if self.check_restart():
             return 0
 
-        # Optional output files (if not added mrun will create them using a generic name)
-        if not self.stage_io_dict["out"].get("output_trr_path"):
-            self.stage_io_dict["out"]["output_trr_path"] = fu.create_name(
-                prefix=self.prefix, step=self.step, name='trajectory.trr')
-            self.tmp_files.append(self.stage_io_dict["out"]["output_trr_path"])
-
         self.stage_files()
 
         if self.container_path:
@@ -151,11 +145,14 @@ class Mdrun(BiobbObject):
             working_dir = self.stage_io_dict.get('unique_dir', '')
 
         self.cmd = [self.binary_path, 'mdrun',
-                    '-o', PurePath(self.stage_io_dict["out"]["output_trr_path"]).name,
                     '-s', PurePath(self.stage_io_dict["in"]["input_tpr_path"]).name,
                     '-c', PurePath(self.stage_io_dict["out"]["output_gro_path"]).name,
                     '-e', PurePath(self.stage_io_dict["out"]["output_edr_path"]).name,
                     '-g', PurePath(self.stage_io_dict["out"]["output_log_path"]).name]
+
+        if self.stage_io_dict["out"].get("output_trr_path"):
+            self.cmd.append('-o')
+            self.cmd.append(PurePath(self.stage_io_dict["out"]["output_trr_path"]).name)
 
         if self.stage_io_dict["in"].get("input_cpt_path"):
             self.cmd.append('-cpi')


### PR DESCRIPTION
# Make trr output files optional

There is no reason to make trr files compulsory I think.

In our MD workflows we use xtc trajectories to save disk space. We don't want to write trr in most cases. If we stage the trr output files by default, biobb_gromacs will complain at some point of not finding the output trr file (because we specify we don't want to write it in the .mdp options)

This could be just an annoying warning, but it breaks the ability to restart the workflow. As biobb_gromacs doesn't find the staged default trr output and starts the minimization/equilibration/production run again. 